### PR TITLE
Fix Dependabot high: nodemailer

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -15,7 +15,7 @@
         "koa-static": "^4.0.3",
         "lodash": "^4.17.20",
         "mongoose": "6.13.6",
-        "nodemailer": "^6.4.18",
+        "nodemailer": "^7.0.11",
         "pinyin": "^3.0.0-alpha.4"
       },
       "bin": {
@@ -5736,9 +5736,9 @@
       }
     },
     "node_modules/nodemailer": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
-      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "version": "7.0.13",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.13.tgz",
+      "integrity": "sha512-PNDFSJdP+KFgdsG3ZzMXCgquO7I6McjY2vlqILjtJd0hy8wEvtugS9xKRF2NWlPNGxvLCXlTNIae4serI7dinw==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"

--- a/server/package.json
+++ b/server/package.json
@@ -16,7 +16,7 @@
     "koa-static": "^4.0.3",
     "lodash": "^4.17.20",
     "mongoose": "6.13.6",
-    "nodemailer": "^6.4.18",
+    "nodemailer": "^7.0.11",
     "pinyin": "^3.0.0-alpha.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Bumps server nodemailer to ^7.0.11 to address Dependabot high severity alert (CVE-2025-14874).

Alert: https://github.com/Nihiue/Thori-dal/security/dependabot/70